### PR TITLE
Bug/dependency update node sass to peer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@brokeds/broke-react",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -84,14 +84,13 @@
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0",
     "webpack-dev-server": "^3.2.1",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-node-externals": "^1.7.2",
+    "jest": "^24.5.0",
+    "jest-resolve": "^24.5.0"
   },
   "peerDependencies": {
     "react": "^16.8.3",
-    "react-dom": "^16.8.3"
-  },
-  "dependencies": {
-    "jest": "^24.5.0",
-    "jest-resolve": "^24.5.0"
+    "react-dom": "^16.8.3",
+    "node-sass": "^4.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brokeds/broke-react",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "BrokeDS React Component Library",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
per issue #8 I've updated the dependencies so that node-sass is a peer I also moved jest and jest-resolve to devdependency from dependency as their is no true end user need for the dependency.